### PR TITLE
test(submission): add unit tests for SubmissionService

### DIFF
--- a/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceCommandTest.java
+++ b/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceCommandTest.java
@@ -18,9 +18,11 @@ import apsas.submission.model.entity.Submission;
 import apsas.submission.repository.SubmissionRepository;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
+import io.qameta.allure.TmsLink;
 import java.util.Optional;
 import java.util.UUID;
 import org.instancio.Instancio;
@@ -41,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Epic("Submission Service")
 @Feature("Service Layer - Command")
+@Issue("12")
 class SubmissionServiceCommandTest {
 
   private static final String CODE_BASE64 = "Y29kZQ==";
@@ -62,6 +65,7 @@ class SubmissionServiceCommandTest {
   @Tag("unit")
   @Story("Create submission")
   @Severity(SeverityLevel.CRITICAL)
+  @TmsLink("SUB-SVC-008")
   @DisplayName("Saves submission and publishes submission created event")
   void createSubmission_shouldSaveAndPublishEvent_whenRequestIsValid() {
     UUID submissionId = UUID.randomUUID();
@@ -109,6 +113,7 @@ class SubmissionServiceCommandTest {
   @Tag("unit")
   @Story("Provide feedback")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-012")
   @DisplayName("Updates feedback and returns mapped response when submission exists")
   void provideFeedback_shouldUpdateFeedbackAndReturnResponse_whenSubmissionExists() {
     UUID submissionId = UUID.randomUUID();
@@ -142,6 +147,7 @@ class SubmissionServiceCommandTest {
   @Tag("unit")
   @Story("Provide feedback")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-013")
   @DisplayName("Throws not found when providing feedback to unknown submission")
   void provideFeedback_shouldThrowNotFoundException_whenSubmissionMissing() {
     UUID submissionId = UUID.randomUUID();

--- a/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceEvaluationTest.java
+++ b/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceEvaluationTest.java
@@ -19,9 +19,11 @@ import apsas.submission.model.entity.SubmissionStatus;
 import apsas.submission.repository.SubmissionRepository;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
+import io.qameta.allure.TmsLink;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Epic("Submission Service")
 @Feature("Service Layer - Evaluation Update")
+@Issue("12")
 class SubmissionServiceEvaluationTest {
 
   @Mock
@@ -61,6 +64,7 @@ class SubmissionServiceEvaluationTest {
   @Tag("unit")
   @Story("Handle evaluated submission event")
   @Severity(SeverityLevel.CRITICAL)
+  @TmsLink("SUB-SVC-009")
   @DisplayName("Updates submission with mapped status result and test case data when evaluation event is valid")
   void handleSubmissionEvaluated_shouldUpdateSubmission_whenEvaluationDataIsProvided() {
     UUID submissionId = UUID.randomUUID();
@@ -104,6 +108,7 @@ class SubmissionServiceEvaluationTest {
   @Tag("unit")
   @Story("Handle evaluated submission event")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-010")
   @DisplayName("Sets evaluatedAt to current time when event does not provide evaluated timestamp")
   void handleSubmissionEvaluated_shouldSetCurrentTime_whenEvaluatedAtIsNull() {
     UUID submissionId = UUID.randomUUID();
@@ -140,6 +145,7 @@ class SubmissionServiceEvaluationTest {
   @Tag("unit")
   @Story("Handle evaluated submission event")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-011")
   @DisplayName("Throws not found when evaluated event references unknown submission")
   void handleSubmissionEvaluated_shouldThrowNotFoundException_whenSubmissionMissing() {
     UUID submissionId = UUID.randomUUID();

--- a/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceQueryTest.java
+++ b/backend/sources/services/submission/test/apsas/submission/service/SubmissionServiceQueryTest.java
@@ -17,9 +17,11 @@ import apsas.submission.model.entity.SubmissionStatus;
 import apsas.submission.repository.SubmissionRepository;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
+import io.qameta.allure.TmsLink;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +48,7 @@ import org.springframework.data.domain.Pageable;
 @ExtendWith(MockitoExtension.class)
 @Epic("Submission Service")
 @Feature("Service Layer - Query")
+@Issue("12")
 class SubmissionServiceQueryTest {
 
   private static final String SECRET_INPUT = "secret-input";
@@ -65,6 +68,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("List submissions for student")
   @Severity(SeverityLevel.CRITICAL)
+  @TmsLink("SUB-SVC-001")
   @DisplayName("Masks hidden test case input and output for student list view")
   void getAllSubmissions_shouldMaskHiddenTestCases_whenRequesterIsStudent() {
     UUID studentId = UUID.randomUUID();
@@ -114,6 +118,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("List submissions for instructor")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-002")
   @DisplayName("Uses instructor filters and keeps hidden test case details unchanged")
   void getAllSubmissions_shouldUseInstructorFilters_whenRequesterIsInstructor() {
     UUID studentId = UUID.randomUUID();
@@ -159,6 +164,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("Get submission by id")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-003")
   @DisplayName("Throws not found when submission id does not exist")
   void getSubmissionById_shouldThrowNotFoundException_whenSubmissionMissing() {
     UUID submissionId = UUID.randomUUID();
@@ -179,6 +185,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("Get submission by id")
   @Severity(SeverityLevel.CRITICAL)
+  @TmsLink("SUB-SVC-004")
   @DisplayName("Throws forbidden when student tries to access another student submission")
   void getSubmissionById_shouldThrowForbiddenException_whenStudentAccessesOthersSubmission() {
     UUID submissionId = UUID.randomUUID();
@@ -204,6 +211,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("Get submission by id")
   @Severity(SeverityLevel.CRITICAL)
+  @TmsLink("SUB-SVC-005")
   @DisplayName("Masks hidden test case details when student reads own submission")
   void getSubmissionById_shouldMaskHiddenTestCases_whenStudentReadsOwnSubmission() {
     UUID submissionId = UUID.randomUUID();
@@ -244,6 +252,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("Get submission by id")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-006")
   @DisplayName("Returns unmasked submission when requester is instructor")
   void getSubmissionById_shouldReturnUnmaskedResult_whenRequesterIsInstructor() {
     UUID submissionId = UUID.randomUUID();
@@ -281,6 +290,7 @@ class SubmissionServiceQueryTest {
   @Tag("unit")
   @Story("Get submission by id")
   @Severity(SeverityLevel.NORMAL)
+  @TmsLink("SUB-SVC-007")
   @DisplayName("Returns response safely when student submission has null test case results")
   void getSubmissionById_shouldReturnResponse_whenTestCaseResultsIsNull() {
     UUID submissionId = UUID.randomUUID();


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `SubmissionService` class, covering all major behaviors including querying, command (write) operations, and evaluation updates. The tests ensure correct data masking, authorization, event publishing, and error handling for both students and instructors.

**Query behavior and authorization:**
- Adds tests to verify that hidden test case details are masked for students but visible to instructors, both in list and detail views. Also tests correct filtering and null-guarding for test case results.
- Ensures that students cannot access other students' submissions (forbidden error), and that not found errors are thrown when appropriate.

**Command/write operations:**
- Adds tests for creating submissions, ensuring both persistence and event publishing are correctly performed.
- Adds tests for providing feedback, including correct update and mapping, as well as error handling when the submission does not exist.

**Evaluation update logic:**
- Adds tests for handling evaluation events, covering correct mapping of status, result, score, test cases, and evaluated time, including fallback logic and not found errors.