### PR TITLE
test(identity): add unit tests for AuthService and User services

### DIFF
--- a/backend/sources/services/identity/test/apsas/identity/security/CustomUserDetailsServiceTest.java
+++ b/backend/sources/services/identity/test/apsas/identity/security/CustomUserDetailsServiceTest.java
@@ -42,8 +42,8 @@ class CustomUserDetailsServiceTest {
 
   @Test
   @TmsLink("IDT-CUDS-001")
-  @DisplayName("Load user details thanh cong bang email")
-  @Story("Xac thuc nguoi dung")
+  @DisplayName("Load user details succeeds by email")
+  @Story("User authentication")
   void loadUserByUsername_shouldReturnUserPrincipal_whenEmailExists() {
     User user = buildUser("student@apsas.dev");
 
@@ -58,8 +58,8 @@ class CustomUserDetailsServiceTest {
 
   @Test
   @TmsLink("IDT-CUDS-002")
-  @DisplayName("Load user details thanh cong bang UUID")
-  @Story("Xac thuc nguoi dung")
+  @DisplayName("Load user details succeeds by UUID")
+  @Story("User authentication")
   void loadUserByUsername_shouldReturnUserPrincipal_whenUuidExists() {
     User user = buildUser("uuid@apsas.dev");
 
@@ -74,8 +74,8 @@ class CustomUserDetailsServiceTest {
 
   @Test
   @TmsLink("IDT-CUDS-003")
-  @DisplayName("Load user details that bai khi email khong ton tai")
-  @Story("Xac thuc nguoi dung")
+  @DisplayName("Load user details fails when email does not exist")
+  @Story("User authentication")
   void loadUserByUsername_shouldThrowUsernameNotFound_whenEmailMissing() {
     when(userRepository.findByEmail("missing@apsas.dev")).thenReturn(Optional.empty());
 
@@ -87,8 +87,8 @@ class CustomUserDetailsServiceTest {
 
   @Test
   @TmsLink("IDT-CUDS-004")
-  @DisplayName("Load user details that bai khi UUID khong ton tai")
-  @Story("Xac thuc nguoi dung")
+  @DisplayName("Load user details fails when UUID does not exist")
+  @Story("User authentication")
   void loadUserByUsername_shouldThrowUsernameNotFound_whenUuidMissing() {
     UUID missingId = UUID.randomUUID();
     String missingUserId = missingId.toString();
@@ -102,8 +102,8 @@ class CustomUserDetailsServiceTest {
 
   @Test
   @TmsLink("IDT-CUDS-005")
-  @DisplayName("Load user details that bai khi input sai dinh dang")
-  @Story("Xac thuc nguoi dung")
+  @DisplayName("Load user details fails when identifier is invalid")
+  @Story("User authentication")
   void loadUserByUsername_shouldThrowUsernameNotFound_whenIdentifierIsInvalid() {
     assertThrows(
         UsernameNotFoundException.class,
@@ -123,5 +123,4 @@ class CustomUserDetailsServiceTest {
         .create();
   }
 }
-
 

--- a/backend/sources/services/identity/test/apsas/identity/service/AuthServiceTest.java
+++ b/backend/sources/services/identity/test/apsas/identity/service/AuthServiceTest.java
@@ -90,9 +90,9 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-001")
-  @DisplayName("Dang ky thanh cong khi email moi")
+  @DisplayName("Register succeeds when email is new")
   @Description("register tra ve auth response, tao token verify va phat su kien user registered")
-  @Story("Dang ky tai khoan")
+  @Story("Account registration")
   @Severity(SeverityLevel.CRITICAL)
   void register_shouldReturnAuthResponse_whenEmailIsNew() {
     RegisterRequest request =
@@ -135,8 +135,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-002")
-  @DisplayName("Dang ky that bai khi email da ton tai")
-  @Story("Dang ky tai khoan")
+  @DisplayName("Register fails when email already exists")
+  @Story("Account registration")
   void register_shouldThrowBadRequest_whenEmailAlreadyExists() {
     RegisterRequest request =
         Instancio.of(RegisterRequest.class)
@@ -151,8 +151,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-003")
-  @DisplayName("Dang nhap thanh cong voi thong tin hop le")
-  @Story("Dang nhap")
+  @DisplayName("Login succeeds with valid credentials")
+  @Story("Login")
   void login_shouldReturnAuthResponse_whenCredentialsAreValid() {
     LoginRequest request = new LoginRequest("user@apsas.dev", "Password@123");
     User user = buildUser("user@apsas.dev", true);
@@ -171,8 +171,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-004")
-  @DisplayName("Dang nhap that bai khi sai mat khau")
-  @Story("Dang nhap")
+  @DisplayName("Login fails when password is incorrect")
+  @Story("Login")
   void login_shouldThrowUnauthorized_whenPasswordIsWrong() {
     LoginRequest request = new LoginRequest("user@apsas.dev", "wrong-pass");
     User user = buildUser("user@apsas.dev", true);
@@ -185,8 +185,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-005")
-  @DisplayName("Dang nhap that bai khi tai khoan bi vo hieu hoa")
-  @Story("Dang nhap")
+  @DisplayName("Login fails when account is inactive")
+  @Story("Login")
   void login_shouldThrowUnauthorized_whenAccountIsInactive() {
     LoginRequest request = new LoginRequest("user@apsas.dev", "Password@123");
     User user = buildUser("user@apsas.dev", false);
@@ -199,8 +199,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-006")
-  @DisplayName("Xac thuc email thanh cong khi token hop le")
-  @Story("Xac thuc email")
+  @DisplayName("Email verification succeeds with valid token")
+  @Story("Email verification")
   void verifyEmail_shouldMarkUserVerified_whenTokenIsValid() {
     User user = buildUser("verify@apsas.dev", true);
     user.setIsEmailVerified(false);
@@ -221,8 +221,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-007")
-  @DisplayName("Xac thuc email that bai khi token khong ton tai")
-  @Story("Xac thuc email")
+  @DisplayName("Email verification fails when token is missing")
+  @Story("Email verification")
   void verifyEmail_shouldThrowBadRequest_whenTokenNotFound() {
     when(emailVerificationTokenRepository.findByToken("missing-token")).thenReturn(Optional.empty());
 
@@ -231,8 +231,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-008")
-  @DisplayName("Xac thuc email that bai khi token het han")
-  @Story("Xac thuc email")
+  @DisplayName("Email verification fails when token is expired")
+  @Story("Email verification")
   void verifyEmail_shouldThrowBadRequest_whenTokenExpired() {
     EmailVerificationToken token = new EmailVerificationToken();
     token.setUser(buildUser("verify@apsas.dev", true));
@@ -246,8 +246,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-009")
-  @DisplayName("Gui lai email verify thanh cong va xoa token cu")
-  @Story("Xac thuc email")
+  @DisplayName("Resend verification email succeeds and replaces old token")
+  @Story("Email verification")
   void resendVerificationEmail_shouldReplaceOldToken_whenUserNotVerified() {
     User user = buildUser("resend@apsas.dev", true);
     user.setIsEmailVerified(false);
@@ -272,8 +272,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-010")
-  @DisplayName("Gui lai email verify that bai khi email da duoc xac thuc")
-  @Story("Xac thuc email")
+  @DisplayName("Resend verification email fails when email is already verified")
+  @Story("Email verification")
   void resendVerificationEmail_shouldThrowBadRequest_whenAlreadyVerified() {
     User user = buildUser("verified@apsas.dev", true);
     EmailRequest request = new EmailRequest(user.getEmail());
@@ -289,8 +289,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-011")
-  @DisplayName("Yeu cau reset password thanh cong")
-  @Story("Khoi phuc mat khau")
+  @DisplayName("Request password reset succeeds")
+  @Story("Password recovery")
   void requestPasswordReset_shouldPublishEvent_whenUserExists() {
     User user = buildUser("reset@apsas.dev", true);
     PasswordResetToken oldToken = new PasswordResetToken();
@@ -313,8 +313,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-012")
-  @DisplayName("Reset password thanh cong voi token hop le")
-  @Story("Khoi phuc mat khau")
+  @DisplayName("Reset password succeeds with valid token")
+  @Story("Password recovery")
   void resetPassword_shouldUpdatePasswordAndDeleteToken_whenTokenIsValid() {
     User user = buildUser("reset@apsas.dev", true);
     PasswordResetToken token = new PasswordResetToken();
@@ -334,8 +334,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-013")
-  @DisplayName("Reset password that bai khi token khong ton tai")
-  @Story("Khoi phuc mat khau")
+  @DisplayName("Reset password fails when token is missing")
+  @Story("Password recovery")
   void resetPassword_shouldThrowBadRequest_whenTokenNotFound() {
     ResetPasswordRequest request = new ResetPasswordRequest("missing-reset-token", "Password@123");
     when(passwordResetTokenRepository.findByToken("missing-reset-token")).thenReturn(Optional.empty());
@@ -348,8 +348,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-014")
-  @DisplayName("Reset password that bai khi token het han")
-  @Story("Khoi phuc mat khau")
+  @DisplayName("Reset password fails when token is expired")
+  @Story("Password recovery")
   void resetPassword_shouldThrowBadRequest_whenTokenExpired() {
     ResetPasswordRequest request = new ResetPasswordRequest("expired-reset-token", "Password@123");
     PasswordResetToken token = new PasswordResetToken();
@@ -368,8 +368,8 @@ class AuthServiceTest {
 
   @Test
   @TmsLink("IDT-AUTH-015")
-  @DisplayName("Gui lai email verify that bai khi khong tim thay user")
-  @Story("Xac thuc email")
+  @DisplayName("Resend verification email fails when user is not found")
+  @Story("Email verification")
   void resendVerificationEmail_shouldThrowNotFound_whenUserMissing() {
     EmailRequest request = org.mockito.Mockito.mock(EmailRequest.class);
     when(request.getEmail()).thenReturn("missing@apsas.dev");
@@ -394,5 +394,4 @@ class AuthServiceTest {
         .create();
   }
 }
-
 

--- a/backend/sources/services/identity/test/apsas/identity/service/UserServiceTest.java
+++ b/backend/sources/services/identity/test/apsas/identity/service/UserServiceTest.java
@@ -62,8 +62,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-001")
-  @DisplayName("Lay user theo id thanh cong")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Get user by id succeeds")
+  @Story("User information management")
   void getUserById_shouldReturnUserResponse_whenUserExists() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("existing@apsas.dev");
@@ -79,8 +79,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-002")
-  @DisplayName("Lay user theo id that bai khi user khong ton tai")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Get user by id fails when user does not exist")
+  @Story("User information management")
   void getUserById_shouldThrowNotFound_whenUserMissing() {
     UUID userId = UUID.randomUUID();
     when(userRepository.findById(userId)).thenReturn(Optional.empty());
@@ -90,8 +90,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-003")
-  @DisplayName("Lay danh sach user theo phan trang")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Get paginated users list")
+  @Story("User information management")
   void getAllUsers_shouldMapPageContent() {
     User user = buildUser("user1@apsas.dev");
     UserResponse response = Instancio.create(UserResponse.class);
@@ -109,8 +109,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-004")
-  @DisplayName("Lay danh sach user theo role va phan trang")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Get paginated users by role")
+  @Story("User information management")
   void getUsersByRole_shouldReturnMappedPage_whenRoleProvided() {
     User user = buildUser("role@apsas.dev");
     UserResponse response = Instancio.create(UserResponse.class);
@@ -130,9 +130,9 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-005")
-  @DisplayName("Tao user thanh cong khi email chua duoc dang ky")
+  @DisplayName("Create user succeeds when email is not registered")
   @Description("createUser luu user moi va tra ve user response")
-  @Story("Quan ly thong tin user")
+  @Story("User information management")
   void createUser_shouldSaveAndReturnResponse_whenEmailIsUnique() {
     CreateUserRequest request =
         Instancio.of(CreateUserRequest.class)
@@ -155,8 +155,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-006")
-  @DisplayName("Tao user that bai khi email da ton tai")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Create user fails when email already exists")
+  @Story("User information management")
   void createUser_shouldThrowBadRequest_whenEmailExists() {
     CreateUserRequest request =
         Instancio.of(CreateUserRequest.class)
@@ -171,8 +171,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-007")
-  @DisplayName("Cap nhat profile chi thay doi truong hop le")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Update profile changes only valid fields")
+  @Story("User information management")
   void updateProfile_shouldUpdateOnlyValidFields_whenRequestContainsBlankValue() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("profile@apsas.dev");
@@ -197,8 +197,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-008")
-  @DisplayName("Cap nhat profile that bai khi user khong ton tai")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Update profile fails when user does not exist")
+  @Story("User information management")
   void updateProfile_shouldThrowNotFound_whenUserMissing() {
     UUID userId = UUID.randomUUID();
     UpdateProfileRequest request = new UpdateProfileRequest("A", "B");
@@ -209,8 +209,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-017")
-  @DisplayName("Cap nhat profile chi cap nhat lastName khi firstName rong")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Update profile changes only lastName when firstName is empty")
+  @Story("User information management")
   void updateProfile_shouldUpdateLastNameOnly_whenFirstNameIsBlank() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("profile2@apsas.dev");
@@ -235,8 +235,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-009")
-  @DisplayName("Doi mat khau thanh cong khi mat khau hien tai dung")
-  @Story("Bao mat tai khoan")
+  @DisplayName("Change password succeeds when current password is correct")
+  @Story("Account security")
   void changePassword_shouldEncodeAndSave_whenCurrentPasswordMatches() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("password@apsas.dev");
@@ -257,8 +257,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-010")
-  @DisplayName("Doi mat khau that bai khi sai mat khau hien tai")
-  @Story("Bao mat tai khoan")
+  @DisplayName("Change password fails when current password is incorrect")
+  @Story("Account security")
   void changePassword_shouldThrowUnauthorized_whenCurrentPasswordIsIncorrect() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("password@apsas.dev");
@@ -277,8 +277,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-011")
-  @DisplayName("Deactivate user se danh dau isActive bang false")
-  @Story("Quan ly trang thai user")
+  @DisplayName("Deactivate user sets isActive to false")
+  @Story("User status management")
   void deactivateUser_shouldSetInactiveAndSave() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("inactive@apsas.dev");
@@ -294,8 +294,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-012")
-  @DisplayName("Activate user se danh dau isActive bang true")
-  @Story("Quan ly trang thai user")
+  @DisplayName("Activate user sets isActive to true")
+  @Story("User status management")
   void activateUser_shouldSetActiveAndSave() {
     UUID userId = UUID.randomUUID();
     User user = buildUser("active@apsas.dev");
@@ -311,8 +311,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-013")
-  @DisplayName("Xoa user that bai khi id khong ton tai")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Delete user fails when id does not exist")
+  @Story("User information management")
   void deleteUser_shouldThrowNotFound_whenIdDoesNotExist() {
     UUID userId = UUID.randomUUID();
     when(userRepository.existsById(userId)).thenReturn(false);
@@ -322,8 +322,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-014")
-  @DisplayName("Xoa user thanh cong khi id ton tai")
-  @Story("Quan ly thong tin user")
+  @DisplayName("Delete user succeeds when id exists")
+  @Story("User information management")
   void deleteUser_shouldDeleteById_whenUserExists() {
     UUID userId = UUID.randomUUID();
     when(userRepository.existsById(userId)).thenReturn(true);
@@ -335,8 +335,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-015")
-  @DisplayName("Tim users theo ids se map thanh user response")
-  @Story("Noi bo cho feign client")
+  @DisplayName("Find users by ids maps to user responses")
+  @Story("Internal for feign client")
   void findUsersByIds_shouldMapAllUsers() {
     User user1 = buildUser("user1@apsas.dev");
     User user2 = buildUser("user2@apsas.dev");
@@ -357,8 +357,8 @@ class UserServiceTest {
 
   @Test
   @TmsLink("IDT-USER-016")
-  @DisplayName("Lay users theo role string hop le")
-  @Story("Noi bo cho feign client")
+  @DisplayName("Get users by valid role string")
+  @Story("Internal for feign client")
   void getUsersByRole_shouldConvertStringRoleAndMapResponses() {
     User user = buildUser("student@apsas.dev");
     user.setRole(UserRole.STUDENT);
@@ -386,4 +386,3 @@ class UserServiceTest {
         .create();
   }
 }
-


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the authentication and user details services in the identity module. These tests cover a wide range of scenarios for user registration, login, email verification, password reset, and user lookup, helping to ensure the reliability and correctness of authentication flows.

**Auth Service Tests:**

* Adds `AuthServiceTest` with tests for user registration, login, email verification, password reset, and related error cases, ensuring correct behavior and error handling for all major authentication flows (`backend/sources/services/identity/test/apsas/identity/service/AuthServiceTest.java`).

**User Details Service Tests:**

* Adds `CustomUserDetailsServiceTest` with tests for loading user details by email and UUID, as well as handling missing or invalid identifiers, improving coverage for user authentication logic (`backend/sources/services/identity/test/apsas/identity/security/CustomUserDetailsServiceTest.java`).